### PR TITLE
nf-docs generation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,5 @@
 _build
 # downloaded from bigbio/quantms
 quantms_output.md
+# for nf-docs
+_nf_docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,15 +21,15 @@ from pathlib import Path
 
 # -- Project information -----------------------------------------------------
 
-project = 'quantms'
-copyright = '2022, daichengxin, jpfeuffer, timosachenberg, ypriverol'
-author = 'daichengxin, jpfeuffer, timosachenberg, ypriverol'
+project = "quantms"
+copyright = "2022, daichengxin, jpfeuffer, timosachenberg, ypriverol"
+author = "daichengxin, jpfeuffer, timosachenberg, ypriverol"
 
 # The full version, including alpha/beta/rc tags
-release = '1.7.0'
+release = "1.7.0"
 
 # Language for this documentation
-language = 'en'
+language = "en"
 
 # -- General configuration ---------------------------------------------------
 
@@ -43,7 +43,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -56,18 +56,18 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'furo'
+html_theme = "furo"
 
 numfig = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Custom CSS files to include
 html_css_files = [
-    'custom.css',
+    "custom.css",
 ]
 
 if os.environ.get("READTHEDOCS") == "True":
@@ -84,14 +84,18 @@ if os.environ.get("READTHEDOCS") == "True":
         # https://www.sphinx-doc.org/en/master/usage/extensions/index.html
         app.connect("builder-inited", download_files)
 
+
 # -- Generating nf-docs ------------------------------------------------------
 
-PIPELINE_GIT = os.environ.get("PIPELINE_GIT", "https://github.com/bigbio/quantms.git") # quantMS repo URL
+PIPELINE_GIT = os.environ.get(
+    "PIPELINE_GIT", "https://github.com/bigbio/quantms.git"
+)  # quantMS repo URL
 PIPELINE_REF = os.environ.get("PIPELINE_REF", "master")  # branch
 GENERATED_DIRNAME = "_nf_docs"  # folder with generated docs
 
+
 def generate_nf_docs(app):
-    srcdir = Path(app.srcdir)   
+    srcdir = Path(app.srcdir)
     outdir = srcdir / GENERATED_DIRNAME
     # avoid re-generating repeatedly
     if outdir.exists():
@@ -101,7 +105,19 @@ def generate_nf_docs(app):
     tmp = Path(tempfile.mkdtemp(prefix="nfdocs-"))
     try:
         # clone only the ref
-        subprocess.run(["git", "clone", "--depth", "1", "--branch", PIPELINE_REF, PIPELINE_GIT, str(tmp)], check=True)
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                PIPELINE_REF,
+                PIPELINE_GIT,
+                str(tmp),
+            ],
+            check=True,
+        )
         # run nf-docs CLI command
         subprocess.run(["nf-docs", "generate", str(tmp)], check=True)
         # move generator output into ReadTheDocs source directory
@@ -117,7 +133,9 @@ def generate_nf_docs(app):
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
+
 def setup(app):
     app.connect("builder-inited", generate_nf_docs)
+
 
 html_extra_path = [GENERATED_DIRNAME]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,11 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import tempfile
+import subprocess
+import shutil
+from pathlib import Path
 
-# import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -80,3 +83,41 @@ if os.environ.get("READTHEDOCS") == "True":
         # on extensions, see:
         # https://www.sphinx-doc.org/en/master/usage/extensions/index.html
         app.connect("builder-inited", download_files)
+
+# -- Generating nf-docs ------------------------------------------------------
+
+PIPELINE_GIT = os.environ.get("PIPELINE_GIT", "https://github.com/bigbio/quantms.git") # quantMS repo URL
+PIPELINE_REF = os.environ.get("PIPELINE_REF", "master")  # branch
+GENERATED_DIRNAME = "_nf_docs"  # folder with generated docs
+
+def generate_nf_docs(app):
+    srcdir = Path(app.srcdir)   
+    outdir = srcdir / GENERATED_DIRNAME
+    # avoid re-generating repeatedly
+    if outdir.exists():
+        shutil.rmtree(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    tmp = Path(tempfile.mkdtemp(prefix="nfdocs-"))
+    try:
+        # clone only the ref
+        subprocess.run(["git", "clone", "--depth", "1", "--branch", PIPELINE_REF, PIPELINE_GIT, str(tmp)], check=True)
+        # run nf-docs CLI command
+        subprocess.run(["nf-docs", "generate", str(tmp)], check=True)
+        # move generator output into ReadTheDocs source directory
+        generated_from_tmp = tmp / "site"
+        if generated_from_tmp.exists():
+            shutil.move(str(generated_from_tmp), str(outdir))
+        else:
+            # fallback: move all files generated in tmp into outdir
+            for p in tmp.iterdir():
+                if p.name == ".git":
+                    continue
+                shutil.move(str(p), str(outdir / p.name))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+def setup(app):
+    app.connect("builder-inited", generate_nf_docs)
+
+html_extra_path = [GENERATED_DIRNAME]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,9 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import tempfile
-import subprocess
 import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 # sys.path.insert(0, os.path.abspath('.'))
@@ -136,6 +136,3 @@ def generate_nf_docs(app):
 
 def setup(app):
     app.connect("builder-inited", generate_nf_docs)
-
-
-html_extra_path = [GENERATED_DIRNAME]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -219,9 +219,10 @@ Navigate to the right section
 
 .. toctree::
    :maxdepth: 1
+   :caption: "Documentation from nf-docs"
    :hidden:
 
-   _nf_docs
+   _nf_docs/*
 |
 
 The following links should be followed to get support and help with the quantms maintainers:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -217,6 +217,13 @@ Navigate to the right section
 
 |
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   _nf_docs
+|
+
 The following links should be followed to get support and help with the quantms maintainers:
 
 |Get help on Slack|   |Report Issue| |Get help on GitHub Forum|

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -215,15 +215,22 @@ Navigate to the right section
    dev
    contact
 
-|
 
 .. toctree::
    :maxdepth: 1
    :caption: "Documentation from nf-docs"
    :hidden:
 
-   _nf_docs/*
-|
+   _nf_docs/.github/CONTRIBUTING
+   _nf_docs/.github/PULL_REQUEST_TEMPLATE
+   _nf_docs/CHANGELOG
+   _nf_docs/CITATIONS
+   _nf_docs/CODE_OF_CONDUCT
+   _nf_docs/README
+   _nf_docs/docs/README
+   _nf_docs/docs/output
+   _nf_docs/docs/usage
+
 
 The following links should be followed to get support and help with the quantms maintainers:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+dependencies = [
+  "nf-docs @ git+https://github.com/edircoli/nf-docs.git@main"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ furo
 myst-nb
 sphinx-new-tab-link
 sphinx-copybutton
+nf-docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ furo
 myst-nb
 sphinx-new-tab-link
 sphinx-copybutton
-nf-docs
+nf-docs @ git+https://github.com/edircoli/nf-docs.git@main


### PR DESCRIPTION
Incorporated nf-docs CLI into the conf.py to generate extra documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Docs build now automatically generates and includes pipeline-specification docs in the published site.
  * Generated pipeline docs are integrated into the site navigation (hidden by default) so pipeline documentation is consolidated with other docs.

* **Chores**
  * Added a tooling dependency to support automated pipeline doc generation.
  * Updated docs ignore rules to exclude generated artifacts from source tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->